### PR TITLE
Now broadcasts raw odom

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,9 +2,13 @@
 Changelog for package thunderborg
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Unreleased
+0.2.0 (2019-03-17)
 ------------------
 * Added the height of the base_link above ground to odom
+* Odometry topic now named /raw_odom and not /odom. Part of adding EKF to fuse IMU data
+* odom /tf now not broadcast from this node. Part of adding EKF to fuse IMU data
+* Parameters moved to /thunderborg_node ns
+* tranform tree now odom<-bade_footprint<-base_link
 
 0.1.1 (2019-01-28)
 ------------------

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Topics:
 * `tacho`:  
   Subscribes using `tacho_msgs/tacho` A message with the current left and right motor rpm
   
-* `/commands/reset_odometry`:  
-  Subscribes using `std_msgs/Empty` A command request to reset the odometry values to zero
+* `/commands/reset_raw_odometry`:  
+  Subscribes using `std_msgs/Empty` A command request to reset the raw odometry values to zero
   
 * `main_battery_status`:  
   Publishes using `sensor_msgs/BatteryState` Message containing the state of the main battery
   
-* `odom`:  
-  Publishes using `nav_msgs/import Odometry` Message containing the odometry data of the robot
+* `raw_odom`:  
+  Publishes using `nav_msgs/Odometry` Message containing the raw odometry data calculated from motor encoders
   
 * `motor1_diag`:  
   Publishes using `geometry_msgs/Vector3` Message contaning diagnostic information for the right hand motor. This message is only published if the parameter server paramter `/speed/motor_diag_msg` is true
@@ -28,11 +28,12 @@ Topics:
   Publishes using `geometry_msgs/Vector3` Message contaning diagnostic information for the left hand motor. This message is only published if the parameter server paramter `/speed/motor_diag_msg` is true
 
 Parameters:
-* `/pid/use_pid`: A flag indicating if the PID should be used to contorl the motors. If True the PID is used. Default value = False
-* `/wheels/distance`: A value giving the distance in metres between the wheels. Default = 0.23
-* `/wheels/circumfrence`: A value giving the circumference of the wheels in metres. Default = 0.34
-* `/speed/slope`: A value giving the slope of the graph used to convert motor velocity to thunderborg motor value. Default = 1.5
-* `/speed/y_intercept`: A value giving the Y intercept of the graph used to convert motor velocity to thunderborg motor value. Default = 0.4
-* `/pid/inertia_level`: A thunderborg motor value at which below the value the motors can't move the robot. Default = 0.0
-* `/speed/motor_diag_msg`: A flag indicating if the motor diagnostic messages should be published. Default = False
+* `~base_height_above_ground`: A value giving the height in meters from the ground to the base_link. Default = 0.09
+* `~pid/use_pid`: A flag indicating if the PID should be used to contorl the motors. If True the PID is used. Default value = False
+* `~wheels/distance`: A value giving the distance in metres between the wheels. Default = 0.23
+* `~wheels/circumfrence`: A value giving the circumference of the wheels in metres. Default = 0.34
+* `~speed/slope`: A value giving the slope of the graph used to convert motor velocity to thunderborg motor value. Default = 1.5
+* `~speed/y_intercept`: A value giving the Y intercept of the graph used to convert motor velocity to thunderborg motor value. Default = 0.4
+* `~pid/inertia_level`: A thunderborg motor value at which below the value the motors can't move the robot. Default = 0.0
+* `~speed/motor_diag_msg`: A flag indicating if the motor diagnostic messages should be published. Default = False
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,11 +1,16 @@
+base_height_above_ground: 0.09
+
 pid:
   use_pid: false
   inertia_level: 0.1
+  
 wheels:
   distance: 0.2423 
   circumference: 0.318
+  
 speed:
   # Plot x=thunderborg value, y=m/s
   slope: 0.649776
   y_intercept: -0.0788956
   motor_diag_msg: false
+

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>thunderborg</name>
-  <version>0.1.2</version>
+  <version>0.2.0</version>
   <description>The thunderborg motor control package</description>
 
   <maintainer email="philip@thehopleys.me.uk">Philip Hopley</maintainer>


### PR DESCRIPTION
Added
- the height of the base_link above ground to odom
- Odometry topic now named /raw_odom and not /odom. Part of adding EKF to fuse IMU data
- odom /tf now not broadcast from this node. Part of adding EKF to fuse IMU data
- Parameters moved to /thunderborg_node ns
- tranform tree now odom<-bade_footprint<-base_link